### PR TITLE
tests: wrapper detects BACKUP_MODE from .env; add README run examples

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -1,4 +1,69 @@
 #!/usr/bin/env bash
-# Wrapper script for backward compatibility
-# Redirects to the new test location
-exec ./test/run-tests.sh "$@"
+# Smart wrapper for running integration tests (keeps backward compatibility)
+# - In BACKUP_MODE=wal it will generate a local SSH key under secrets/walg_ssh_key
+#   so the postgres wal-g setup can proceed in the test container.
+# - It chooses sensible environment flags depending on BACKUP_MODE.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_SCRIPT="$SCRIPT_DIR/test/run-tests.sh"
+
+if [[ ! -f "$TEST_SCRIPT" ]]; then
+	echo "Error: test script not found at $TEST_SCRIPT" >&2
+	exit 2
+fi
+
+# Determine mode from environment or .env
+BACKUP_MODE="${BACKUP_MODE:-}"
+if [[ -z "$BACKUP_MODE" && -f "$SCRIPT_DIR/.env" ]]; then
+	# shellcheck disable=SC1090
+	# Source .env into the current shell so exported values (like BACKUP_MODE)
+	# are available to this script. We temporarily enable allexport so simple
+	# KEY=VALUE lines are exported as environment variables.
+	set -o allexport
+	source "$SCRIPT_DIR/.env" >/dev/null 2>&1 || true
+	set +o allexport
+	BACKUP_MODE="${BACKUP_MODE:-}"
+fi
+
+run_sql_mode() {
+	echo "Running tests in SQL backup mode..."
+	# keep simple invocation for SQL mode
+	BACKUP_MODE=sql CLEANUP=1 "$TEST_SCRIPT" "$@"
+}
+
+run_wal_mode() {
+	echo "Running tests in WAL (wal-g) backup mode..."
+	# Ensure we have a local SSH key for the test (do not overwrite existing keys)
+	mkdir -p "$SCRIPT_DIR/secrets/walg_ssh_key"
+	if [[ ! -f "$SCRIPT_DIR/secrets/walg_ssh_key/id_rsa" ]]; then
+		echo "Generating temporary SSH key for wal-g tests at secrets/walg_ssh_key/id_rsa"
+		ssh-keygen -t rsa -b 2048 -f "$SCRIPT_DIR/secrets/walg_ssh_key/id_rsa" -N "" -q
+		chmod 600 "$SCRIPT_DIR/secrets/walg_ssh_key/id_rsa"
+		chmod 644 "$SCRIPT_DIR/secrets/walg_ssh_key/id_rsa.pub"
+	else
+		echo "Using existing key at secrets/walg_ssh_key/id_rsa"
+	fi
+
+	# Recommended env set: empty pgdata to avoid pre-populated image data, skip network ssh-keyscan to avoid external network, cleanup afterwards
+	FORCE_EMPTY_PGDATA=1 SKIP_SSH_KEYSCAN=1 BACKUP_MODE=wal CLEANUP=1 "$TEST_SCRIPT" "$@"
+}
+
+case "$BACKUP_MODE" in
+	wal|WAL|Wal)
+		run_wal_mode "$@"
+		;;
+	sql|SQL|Sql)
+		run_sql_mode "$@"
+		;;
+	"")
+		# Default to SQL mode for safety if not specified
+		echo "No BACKUP_MODE detected; defaulting to SQL mode (safer)." >&2
+		run_sql_mode "$@"
+		;;
+	*)
+		echo "Unknown BACKUP_MODE='$BACKUP_MODE' - please set BACKUP_MODE=sql or wal" >&2
+		exit 3
+		;;
+esac

--- a/test/README.org
+++ b/test/README.org
@@ -12,17 +12,13 @@ This file contains comprehensive tests for the PostgreSQL backup stack project. 
 
 ** Usage
 
-Execute the test script directly:
+Execute the test script directly from repository root:
 
-#+begin_src bash
 ./run-tests.sh
-#+end_src
 
 Or with cleanup enabled (brings down the stack after tests):
 
-#+begin_src bash
 CLEANUP=1 ./run-tests.sh
-#+end_src
 
 ** Test Coverage
 
@@ -81,15 +77,13 @@ Below are a couple of copyable examples for running the test runner safely.
   `postgres-data` volume, skip ssh-keyscan (useful in isolated CI), run in WAL
   mode and clean up afterwards:
 
-#+begin_src bash
-FORCE_EMPTY_PGDATA=1 SKIP_SSH_KEYSCAN=1 BACKUP_MODE=wal CLEANUP=1 ../run-tests.sh
-#+end_src
+Run from repository root (the wrapper will create a local SSH key under secrets/walg_ssh_key if needed):
+
+FORCE_EMPTY_PGDATA=1 SKIP_SSH_KEYSCAN=1 BACKUP_MODE=wal CLEANUP=1 ./run-tests.sh
 
 - SQL-mode (validate rclone/age backup tooling). No destructive volume clear:
 
-#+begin_src bash
-BACKUP_MODE=sql CLEANUP=1 ../run-tests.sh
-#+end_src
+BACKUP_MODE=sql CLEANUP=1 ./run-tests.sh
 
 ** Test Implementation
 


### PR DESCRIPTION
This pull request updates the test runner script and documentation to support both SQL and WAL backup modes, improve usability, and clarify usage. The main change is a new smart wrapper script for running integration tests, which automatically handles environment setup and SSH key generation for WAL mode. The documentation is updated to reflect these changes and provide clearer instructions.

**Test runner improvements:**

* Replaced the old `run-tests` wrapper script with a new version that automatically detects the backup mode, sources environment variables from `.env` if present, and generates a local SSH key for WAL mode under `secrets/walg_ssh_key` if needed. It chooses sensible environment flags depending on the backup mode and provides clear error messages for misconfiguration. (`run-tests`)

**Documentation updates:**

* Updated usage instructions in `test/README.org` to indicate that tests should be run from the repository root using `./run-tests.sh`, and removed outdated examples referencing subdirectories. (`test/README.org`)
* Revised example commands in `test/README.org` to use the new wrapper script from the repository root, and clarified how the wrapper handles SSH key generation and backup mode selection. (`test/README.org`)